### PR TITLE
Update README.md with current urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@
   </p>
 </div>
 
-[![GitHub contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
-[![Issues][issues-shield]][issues-url]
 
 ***
 


### PR DESCRIPTION

## Type of Change

Documentation

## Context

README.md was broken because the git repo is private, so the bot is no longer allowed to access the stargazers/info about it

## Changes Made

- removed URLS in readme for stargazers etc. 
- Removed linkedin URL

## Screenshots

![image](https://github.com/TCU-ClassifAI/classifAI/assets/29128358/bd238dac-c193-48a7-9709-6339c2dd3bf9)


## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation, if applicable
- [x] I have added unit tests, if applicable (NA)
