### PR TITLE
Update docker-compose.yml

### DIFF
--- a/resources/docker-compose.yml
+++ b/resources/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./mongo-data:/data/db
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     ports:
-      - "127.0.0.1:27017:27017"
+      - "0.0.0.0:27017:27017"
     
 volumes:
   mongo-data:


### PR DESCRIPTION
## Type of Change

Bug Fix


## Context

Specifically specifying localhost via 127.0.0.1 does not allow for remote connections to be made. Changing it to 0.0.0.0 exposes it to the broader internet (dont worry the firewall still blocks all requests except from llm.cs.tcu.edu)

## Changes Made

- Changed config of docker-compose file to run on 0.0.0.0 instead of 127.0.0.1

## Screenshots
![image](https://github.com/TCU-ClassifAI/classifAI/assets/29128358/9ee53894-c4f6-4a26-826c-7fd9c094211f)

![image](https://github.com/TCU-ClassifAI/classifAI/assets/29128358/9b427def-55f6-482c-9d77-9aeaa8316bbb)


## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation, if applicable
- [x] I have added unit tests, if applicable
