### PR TITLE
YouTube title instead of URL

### DIFF
--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -293,7 +293,8 @@ async function updateTransferDataStatus(reports) {
         }
 
         if (response.data.meta.title){
-          report.transferData["fileName"] = response.data.meta.title;
+          //report.transferData["fileName"] = response.data.meta.title;
+          report.files["fileName"] = response.data.meta.title;
         }
 
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -294,11 +294,14 @@ async function updateTransferDataStatus(reports) {
 
         console.log(response.data.meta.title);
         if (response.data.meta.title){
-          //report.transferData["fileName"] = response.data.meta.title;
-          report.files.push({
+          
+
+          // if not already existing, then push to mongo db report.files[]
+
+          report.files[0]={
             fileName: response.data.meta.title,
             fileType: 'YouTube',
-          });
+          };
         }
 
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -294,7 +294,6 @@ async function updateTransferDataStatus(reports) {
 
         if (response.data.meta.title){
           report.transferData["fileName"] = response.data.meta.title;
-          report.audioFile = response.data.meta.title;
         }
 
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -305,6 +305,7 @@ async function updateTransferDataStatus(reports) {
 
         if (response.data.meta.title){
           report.audioFile = response.data.meta.title +' YouTube';
+          report.transferData["fileName"] = response.data.meta.title +' YouTube';
 
           // if not already existing, then push to mongo db report.files[]
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -292,6 +292,11 @@ async function updateTransferDataStatus(reports) {
           report.transferData["result"] = response.data.result;
         }
 
+        if (response.data.meta.title){
+          report.transferData["fileName"] = response.data.meta.title;
+          report.audioFile = response.data.meta.title;
+        }
+
 
       } catch (error) {
         console.error(

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -86,6 +86,7 @@ router.get("/users/:userId", async (req, res) => {
           subject: report.subject,
           fileName: filteredFiles.map((file) => file.fileName),
           transferData: report.transferData,
+          audioFile: report.audioFile,
         });
       }
     });

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -300,6 +300,7 @@ async function updateTransferDataStatus(reports) {
 
           report.files[0]={
             fileName: response.data.meta.title,
+            filePath: 'testLink',
             fileType: 'YouTube',
           };
         }

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -292,7 +292,6 @@ async function updateTransferDataStatus(reports) {
           report.transferData["result"] = response.data.result;
         }
 
-        console.log(response.data.meta.title);
         if (response.data.meta.title){
           
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -118,6 +118,16 @@ router.get("/:reportId/users/:userId", async (req, res) => {
     // Returns llm info
     reports = await updateTransferDataStatus(reports);
 
+    // New functionality: WIP question categorization if categorize paramter === true
+    // if (req.query.categorize === 'true') {
+    //   reports = categorizeReports(reports);
+    // }
+
+    // New functionality: WIP summarize if summarize paramter === true
+    // if (req.query.summarize === 'true') {
+    //   reports = summarizeReports(reports);
+    // }
+
     res.json({ success: true, reports: reports });
   } catch (error) {
     console.error(error);
@@ -294,15 +304,15 @@ async function updateTransferDataStatus(reports) {
         }
 
         if (response.data.meta.title){
-          
+          report.audioFile = response.data.meta.title;
 
           // if not already existing, then push to mongo db report.files[]
 
-          report.files[0]={
-            fileName: response.data.meta.title,
-            filePath: 'testLink',
-            fileType: 'YouTube',
-          };
+          // report.files[0]={
+          //   fileName: response.data.meta.title,
+          //   filePath: 'testLink',
+          //   fileType: 'YouTube',
+          // };
         }
 
 
@@ -323,5 +333,27 @@ async function updateTransferDataStatus(reports) {
   }
   return reports; // Return updated reports
 }
+
+
+// async function categorizeReports(report){
+//   if (report.transferData.status === "finished") {
+//     // make and send a JSON file of reports.transferData.result to endpoint
+
+//   try {
+//     const response = await axios.post(
+//       `${process.env.WORKSTATION_URL}/categorize/categorize_transcript`,
+//       {
+//         //the json file of reports.transferData.result to endpoint
+//       }
+//     );
+    
+//   }
+
+//   catch (error) {
+
+//   }
+  
+//   }
+// }
 
 module.exports = router;

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -292,9 +292,13 @@ async function updateTransferDataStatus(reports) {
           report.transferData["result"] = response.data.result;
         }
 
+        console.log(response.data.meta.title);
         if (response.data.meta.title){
           //report.transferData["fileName"] = response.data.meta.title;
-          report.files["fileName"] = response.data.meta.title;
+          report.files.push({
+            fileName: response.data.meta.title,
+            fileType: 'YouTube',
+          });
         }
 
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -305,15 +305,14 @@ async function updateTransferDataStatus(reports) {
 
         if (response.data.meta.title){
           report.audioFile = response.data.meta.title +' YouTube';
-          report.transferData["fileName"] = response.data.meta.title +' YouTube';
 
           // if not already existing, then push to mongo db report.files[]
 
-          // report.files[0]={
-          //   fileName: response.data.meta.title,
-          //   filePath: 'testLink',
-          //   fileType: 'YouTube',
-          // };
+          report.files[0]={
+            fileName: response.data.meta.title,
+            filePath: 'testLink',
+            fileType: 'YouTube',
+          };
         }
 
 

--- a/backend/routes/reportRoutes.js
+++ b/backend/routes/reportRoutes.js
@@ -304,7 +304,7 @@ async function updateTransferDataStatus(reports) {
         }
 
         if (response.data.meta.title){
-          report.audioFile = response.data.meta.title;
+          report.audioFile = response.data.meta.title +' YouTube';
 
           // if not already existing, then push to mongo db report.files[]
 

--- a/backend/routes/reportUploadRoute.js
+++ b/backend/routes/reportUploadRoute.js
@@ -128,7 +128,7 @@ router.post(
           const job_id = ytResponse.data.job_id; // Return job_id to the client for polling
           //console.log('job id:',job_id);
 
-          const yt_title = ytResponse.data.title;
+          //const yt_title = ytResponse.data.title;
           //let job = await getInitialJobReq(process.env.WORKSTATION_URL, job_id);
           
           // let transcriptionData = {
@@ -147,7 +147,7 @@ router.post(
           report.transferData = {
             //...transcriptionData,
             job_id: job_id,
-            fileName: yt_title || url, //providedFileName || path.basename(newPath),
+            fileName: url, //providedFileName || path.basename(newPath),
           };
 
           //('transfer data:' ,report.transferData);
@@ -156,7 +156,7 @@ router.post(
             {
               transferData: report.transferData,
               //status: job.data.status,
-              audioFile: yt_title ||url, //providedFileName || path.basename(newPath),
+              audioFile: url, //providedFileName || path.basename(newPath),
             }
           );
         } catch (error) {


### PR DESCRIPTION
## Type of Change

When queried, express will replace the youtube link in fileName with the llm's meta YouTube title

## Changes Made

- if response.data.meta.title then replace fileName with YouTube video title

## Screenshots

![image](https://github.com/TCU-ClassifAI/classifAI/assets/104051323/01442a6f-de6e-4672-b93a-1c909d2230aa)
![image](https://github.com/TCU-ClassifAI/classifAI/assets/104051323/fa9b9df6-3710-4383-a3ec-c4bc3651b933)



## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation, if applicable
- [ ] I have added unit tests, if applicable
